### PR TITLE
Add Marktplaats login script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MARKTPLAATS_EMAIL=your-email@example.com
+MARKTPLAATS_PASSWORD=your-password

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# 3dmodelgenerator
+# Marktplaats Login App
+
+This repository provides a simple Python script that logs in to [Marktplaats](https://www.marktplaats.nl/) using credentials stored in a `.env` file.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your email and password.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the script:
+   ```bash
+   python login.py
+   ```
+
+The script will attempt to authenticate and print the response status code and body.

--- a/login.py
+++ b/login.py
@@ -1,0 +1,54 @@
+import os
+import json
+import re
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+EMAIL = os.getenv("MARKTPLAATS_EMAIL")
+PASSWORD = os.getenv("MARKTPLAATS_PASSWORD")
+
+if not EMAIL or not PASSWORD:
+    raise SystemExit("Please set MARKTPLAATS_EMAIL and MARKTPLAATS_PASSWORD in the .env file")
+
+SESSION = requests.Session()
+LOGIN_PAGE = "https://www.marktplaats.nl/identity/v2/login"
+LOGIN_API = "https://www.marktplaats.nl/identity/v2/api/login"
+
+# Fetch login page to obtain xsrf token and threatMetrix information
+resp = SESSION.get(LOGIN_PAGE)
+resp.raise_for_status()
+
+# Extract xsrf token
+xsrf_match = re.search(r'"xsrfToken":"([^"]+)"', resp.text)
+if not xsrf_match:
+    raise SystemExit("Unable to find xsrf token on login page")
+xsrf_token = xsrf_match.group(1)
+
+# Extract threatMetrix object
+threat_match = re.search(r'"threatMetrix":\{([^}]+)\}', resp.text)
+if threat_match:
+    threat_json = '{' + threat_match.group(1) + '}'
+    try:
+        threat_data = json.loads(threat_json)
+    except json.JSONDecodeError:
+        threat_data = {}
+else:
+    threat_data = {}
+
+payload = {
+    "email": EMAIL,
+    "password": PASSWORD,
+    "rememberMe": True,
+    "threatMetrix": threat_data
+}
+
+headers = {
+    "Content-Type": "application/json",
+    "X-XSRF-TOKEN": xsrf_token
+}
+
+resp = SESSION.post(LOGIN_API, json=payload, headers=headers)
+print(f"Status code: {resp.status_code}")
+print(resp.text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dotenv
+requests


### PR DESCRIPTION
## Summary
- add Python script that logs into Marktplaats using credentials from `.env`
- include example `.env` and dependencies
- document setup in README

## Testing
- `pip install -r requirements.txt`
- `python login.py`

------
https://chatgpt.com/codex/tasks/task_e_6899036fc324832e9c12ff72815bf7fa