### PR TITLE
Add Flask web interface and Render deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Marktplaats Login App
 
-This repository provides a simple Python script that logs in to [Marktplaats](https://www.marktplaats.nl/) using credentials stored in a `.env` file.
+This repository provides a simple Python script that logs in to [Marktplaats](https://www.marktplaats.nl/) using credentials stored in a `.env` file.  A minimal Flask web interface is included so the script can be run as a small website.
 
 ## Setup
 
@@ -9,9 +9,27 @@ This repository provides a simple Python script that logs in to [Marktplaats](ht
    ```bash
    pip install -r requirements.txt
    ```
-3. Run the script:
+3. Run the script directly:
    ```bash
    python login.py
    ```
 
-The script will attempt to authenticate and print the response status code and body.
+## Run the web app
+
+Start the Flask web server:
+
+```bash
+flask --app app run
+```
+
+Visit <http://localhost:5000> to use the login form.  The page posts to `/login` and displays the status code and response body.
+
+## Deploy on Render (free tier)
+
+1. Push this repository to GitHub.
+2. Create an account at [Render](https://render.com/) and select **New Web Service**.
+3. Connect the GitHub repository.
+4. Use the following settings:
+   - **Build Command:** `pip install -r requirements.txt`
+   - **Start Command:** `gunicorn app:app`
+5. After deployment, the site will be accessible at the URL provided by Render.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+from flask import Flask, request, jsonify, render_template
+from login import perform_login
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/login", methods=["POST"])
+def login_route():
+    data = request.form or request.json or {}
+    email = data.get("email")
+    password = data.get("password")
+    if not email or not password:
+        return jsonify({"error": "Email and password are required"}), 400
+    result = perform_login(email, password)
+    return jsonify(result)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/login.py
+++ b/login.py
@@ -6,49 +6,63 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-EMAIL = os.getenv("MARKTPLAATS_EMAIL")
-PASSWORD = os.getenv("MARKTPLAATS_PASSWORD")
-
-if not EMAIL or not PASSWORD:
-    raise SystemExit("Please set MARKTPLAATS_EMAIL and MARKTPLAATS_PASSWORD in the .env file")
-
-SESSION = requests.Session()
 LOGIN_PAGE = "https://www.marktplaats.nl/identity/v2/login"
 LOGIN_API = "https://www.marktplaats.nl/identity/v2/api/login"
 
-# Fetch login page to obtain xsrf token and threatMetrix information
-resp = SESSION.get(LOGIN_PAGE)
-resp.raise_for_status()
 
-# Extract xsrf token
-xsrf_match = re.search(r'"xsrfToken":"([^"]+)"', resp.text)
-if not xsrf_match:
-    raise SystemExit("Unable to find xsrf token on login page")
-xsrf_token = xsrf_match.group(1)
+def perform_login(email: str, password: str) -> dict:
+    """Attempt to log in to Marktplaats with provided credentials."""
+    if not email or not password:
+        raise ValueError("Email and password are required")
 
-# Extract threatMetrix object
-threat_match = re.search(r'"threatMetrix":\{([^}]+)\}', resp.text)
-if threat_match:
-    threat_json = '{' + threat_match.group(1) + '}'
-    try:
-        threat_data = json.loads(threat_json)
-    except json.JSONDecodeError:
+    session = requests.Session()
+
+    # Fetch login page to obtain xsrf token and threatMetrix information
+    resp = session.get(LOGIN_PAGE)
+    resp.raise_for_status()
+
+    # Extract xsrf token
+    xsrf_match = re.search(r'"xsrfToken":"([^"]+)"', resp.text)
+    if not xsrf_match:
+        raise RuntimeError("Unable to find xsrf token on login page")
+    xsrf_token = xsrf_match.group(1)
+
+    # Extract threatMetrix object
+    threat_match = re.search(r'"threatMetrix":\{([^}]+)\}', resp.text)
+    if threat_match:
+        threat_json = '{' + threat_match.group(1) + '}'
+        try:
+            threat_data = json.loads(threat_json)
+        except json.JSONDecodeError:
+            threat_data = {}
+    else:
         threat_data = {}
-else:
-    threat_data = {}
 
-payload = {
-    "email": EMAIL,
-    "password": PASSWORD,
-    "rememberMe": True,
-    "threatMetrix": threat_data
-}
+    payload = {
+        "email": email,
+        "password": password,
+        "rememberMe": True,
+        "threatMetrix": threat_data,
+    }
 
-headers = {
-    "Content-Type": "application/json",
-    "X-XSRF-TOKEN": xsrf_token
-}
+    headers = {
+        "Content-Type": "application/json",
+        "X-XSRF-TOKEN": xsrf_token,
+    }
 
-resp = SESSION.post(LOGIN_API, json=payload, headers=headers)
-print(f"Status code: {resp.status_code}")
-print(resp.text)
+    resp = session.post(LOGIN_API, json=payload, headers=headers)
+    return {"status_code": resp.status_code, "text": resp.text}
+
+
+if __name__ == "__main__":
+    EMAIL = os.getenv("MARKTPLAATS_EMAIL")
+    PASSWORD = os.getenv("MARKTPLAATS_PASSWORD")
+
+    if not EMAIL or not PASSWORD:
+        raise SystemExit(
+            "Please set MARKTPLAATS_EMAIL and MARKTPLAATS_PASSWORD in the .env file"
+        )
+
+    result = perform_login(EMAIL, PASSWORD)
+    print(f"Status code: {result['status_code']}")
+    print(result["text"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-dotenv
 requests
+Flask
+gunicorn

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Marktplaats Login</title>
+</head>
+<body>
+    <h1>Marktplaats Login</h1>
+    <form id="login-form">
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Password: <input type="password" name="password" required></label><br>
+        <button type="submit">Login</button>
+    </form>
+    <pre id="result"></pre>
+    <script>
+        const form = document.getElementById('login-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const formData = new FormData(form);
+            const resp = await fetch('/login', {
+                method: 'POST',
+                body: formData
+            });
+            const data = await resp.json();
+            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Refactor login script into a reusable function
- Add Flask web interface with HTML form and API endpoint
- Document deploying the app on Render's free tier

## Testing
- `python -m py_compile login.py app.py`
- `python -m pytest`
- `pip install -r requirements.txt`
- `python app.py` (server started)


------
https://chatgpt.com/codex/tasks/task_e_6899e894847c832e91135a14f1d610c9